### PR TITLE
Implement main

### DIFF
--- a/miniauth/main.py
+++ b/miniauth/main.py
@@ -5,6 +5,7 @@ MiniAuth program interface.
 """
 import sys
 from argparse import ArgumentParser
+from getpass import getpass
 from logging import getLogger, INFO, DEBUG, StreamHandler, Logger, NullHandler
 from miniauth import __version__
 from miniauth.auth import MiniAuth
@@ -45,6 +46,7 @@ def parse_args(args=None):
     parser_enable = subparsers.add_parser('enable', help='enable an existing user')
     parser_enable.add_argument('--ignore-missing', '-i', action='store_true', help='ignore missing user')
     parser_enable.add_argument('user', help='username to remove')
+
 
     return parser.parse_args(args)
 
@@ -117,7 +119,7 @@ def main(args=None):
 
         mini_auth = MiniAuth(db_path=opts.storage)
         if opts.action == 'save':
-            password = opts.password or prompt_password()
+            password = opts.password or getpass()
             return save_user(mini_auth, opts.user, password, opts.hash, opts.force)
         if opts.action == 'remove':
             return remove_user(mini_auth, opts.user, opts.ignore_missing)

--- a/miniauth/main.py
+++ b/miniauth/main.py
@@ -1,0 +1,134 @@
+"""
+miniauth.main
+~~~~~~~~~~~~~
+MiniAuth program interface.
+"""
+import sys
+from argparse import ArgumentParser
+from logging import getLogger, INFO, DEBUG, StreamHandler, Logger, NullHandler
+from miniauth import __version__
+from miniauth.auth import MiniAuth
+from miniauth.typing import Text
+
+# corresponding os.EX_* if available
+EX_OK = 0
+EX_ALREADY_EXISTS = 1
+EX_NOUSER = 67
+EX_TEMPFAIL = 75
+EX_SOFTWARE = 70
+
+logger = getLogger()  # type: Logger
+
+
+def parse_args(args=None):
+    parser = ArgumentParser(prog='miniauth', description="manage a database of users")
+    parser.add_argument('-s', '--storage', default='miniauth.db', help='the auth storage. default is miniauth.db')
+    parser.add_argument('-q', '--quiet', action='store_true', help='run in quiet mode (overwrites verbose)')
+    parser.add_argument('-v', '--verbose', action='store_true', help='run in verbose mode')
+    parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
+    subparsers = parser.add_subparsers(dest='action', help='available actions')
+
+    parser_user = subparsers.add_parser('save', help='create or update a user')
+    parser_user.add_argument('--hash', default='sha512', help='hash function to use (default: sha512)')
+    parser_user.add_argument('--password', '-p', help='password')
+    parser_user.add_argument('--force', '-f', action='store_true', help='force update user, overwrite existing')
+    parser_user.add_argument('user', help='username (is unique)')
+
+    parser_remove = subparsers.add_parser('remove', help='remove a user')
+    parser_remove.add_argument('--ignore-missing', '-i', action='store_true', help='ignore missing user')
+    parser_remove.add_argument('user', help='username to remove')
+
+    parser_disable = subparsers.add_parser('disable', help='disable an existing user')
+    parser_disable.add_argument('--ignore-missing', '-i', action='store_true', help='ignore missing user')
+    parser_disable.add_argument('user', help='username to remove')
+
+    parser_enable = subparsers.add_parser('enable', help='enable an existing user')
+    parser_enable.add_argument('--ignore-missing', '-i', action='store_true', help='ignore missing user')
+    parser_enable.add_argument('user', help='username to remove')
+
+    return parser.parse_args(args)
+
+
+def configure_logger(logger, quiet=False, debug=False):
+    # type: (Logger, bool, bool) -> None
+    logger.setLevel(DEBUG)
+    if quiet:
+        logger.addHandler(NullHandler())
+    else:
+        stdout_handler = StreamHandler(stream=sys.stdout)
+        stdout_handler.setLevel(DEBUG if debug else INFO)
+        logger.addHandler(stdout_handler)
+
+
+def save_user(mini_auth, user, password, hash_, force=False):
+    # type: (MiniAuth, Text, Text, str, bool) -> int
+    if mini_auth.user_exists(user) and not force:
+        logger.warning("user {} already exists. use force to update".format(user))
+        return EX_ALREADY_EXISTS
+    created = mini_auth.create_user(user, password, hash_func=hash_)
+    logger.debug(
+        "{} user {}".format('created' if created else 'updated', user)
+    )
+    return EX_OK
+
+
+def remove_user(mini_auth, user, ignore_missing=False):
+    # type: (MiniAuth, Text, bool) -> int
+    if mini_auth.delete_user(user):
+        logger.debug("removed user {}".format(user))
+        return EX_OK
+    logger.info("user {} didn't exit".format(user))
+    return EX_OK if ignore_missing else EX_NOUSER
+
+
+def disable_user(mini_auth, user, ignore_missing=False):
+    # type: (MiniAuth, Text, bool) -> int
+    if not mini_auth.user_exists(user):
+        logger.warning("user {} does not exist".format(user))
+        return EX_OK if ignore_missing else EX_NOUSER
+    if mini_auth.disable_user(user):
+        logger.debug("disabled user {}".format(user))
+        return EX_OK
+    logger.warning("could not disable user {}".format(user))
+    return EX_SOFTWARE
+
+
+def enable_user(mini_auth, user, ignore_missing=False):
+    # type: (MiniAuth, Text, bool) -> int
+    if not mini_auth.user_exists(user):
+        logger.warning("user {} does not exist".format(user))
+        return EX_OK if ignore_missing else EX_NOUSER
+    if mini_auth.enable_user(user):
+        logger.debug("enabled user {}".format(user))
+        return EX_OK
+    logger.warning("could not enable user {}".format(user))
+    return EX_SOFTWARE
+
+
+def verify_user(user, password):
+    # type: (Text, Text) -> int
+    pass
+
+
+def main(args=None):
+    try:
+        opts = parse_args(args)
+        configure_logger(logger, quiet=opts.quiet)
+
+        mini_auth = MiniAuth(db_path=opts.storage)
+        if opts.action == 'save':
+            password = opts.password or prompt_password()
+            return save_user(mini_auth, opts.user, password, opts.hash, opts.force)
+        if opts.action == 'remove':
+            return remove_user(mini_auth, opts.user, opts.ignore_missing)
+        if opts.action == 'disable':
+            return disable_user(mini_auth, opts.user, opts.ignore_missing)
+        if opts.action == 'enable':
+            return enable_user(mini_auth, opts.user, opts.ignore_missing)
+    except KeyboardInterrupt:
+        logger.debug("process interrupted")
+        return EX_TEMPFAIL
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/miniauth/utils.py
+++ b/miniauth/utils.py
@@ -1,0 +1,65 @@
+"""
+miniauth.utils
+~~~~~~~~~~~~~~
+utility functions and helpers
+"""
+import sys
+from contextlib import closing
+from .typing import List
+from io import BytesIO, StringIO
+
+# Python 2 StringIO uses unicode, but Python 2 argparser returns str.
+# By using BytesIO we can avoids this. MemTextIO is a safe alias
+# to use for any text based memory IO.
+MemTextIO = BytesIO if sys.version_info[0] == 2 else StringIO
+
+try:
+    _raw_input = raw_input
+except NameError:  # Python 3 renamed raw_input to input
+    _raw_input = input
+
+
+def prompt(message='', on_empty_msg='Please enter a value'):
+    while True:
+        resp = _raw_input(message).strip()
+        if resp:
+            return resp
+        print(on_empty_msg)
+
+
+def read_lines_from_stream(stream, count=None):
+    """Read lines from the stream/file object. If a count is specified
+    would limit the number of lines read.  If there are fewer lines than count,
+    the rest of the list would be None items.
+    Empty lines are not filtered out and count as a line.
+    """
+    # type (Any, int) -> List[Text]
+    if not count:
+        return [l.strip("\n") for l in stream.readlines()]
+    lines = []
+    line_counter = 0
+    for line in stream:
+        line_counter += 1
+        lines.append(line.strip("\n"))
+        if line_counter >= count:
+            break
+    if line_counter < count:
+        lines.extend([None] * (count - line_counter))
+    return lines
+
+
+def read_lines_from_file(file_name, count=None):
+    """Read lines from the file. If a count is specified
+    would limit the number of lines read from the file.
+    If the file has fewer lines than count, the rest of the list would be None items
+    Empty lines are not filtered out and count as a line.
+
+    file_name can be a path to a file, or '-' for standard input.
+    file handlers are closed, but not stdin.
+    """
+    # type (Text, int) -> List[Text]
+    if file_name == '-':
+        return read_lines_from_stream(sys.stdin, count)
+
+    with closing(open(file_name, 'rt')) as fh:
+        return read_lines_from_stream(fh, count)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,18 +14,20 @@ class BaseTestCase(TestCase):
 
 
 class HasTempfileTestCase(BaseTestCase):
-    _tempfile_mode = 'w+b'
-    _tempfile_prefix = 'tmp'
-    _tempfile_dir = None
+    _temp_file_mode = 'w+b'
+    _temp_file_prefix = 'tmp'
+    _temp_file_dir = None
 
-    def _create_temp_file(self):
-        return NamedTemporaryFile(
-                mode=self._tempfile_mode,
-                prefix=self._tempfile_prefix,
-                dir=self._tempfile_dir
+    def _create_temp_file(self, auto_close=True):
+        temp_file = NamedTemporaryFile(
+                mode=self._temp_file_mode,
+                prefix=self._temp_file_prefix,
+                dir=self._temp_file_dir
                )
+        if auto_close:
+            self.addCleanup(temp_file.close)
+        return temp_file
 
     def setUp(self):
         self._tempfile = self._create_temp_file()
-        self.addCleanup(self._tempfile.close)
         self._tempfile_name = self._tempfile.name

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,392 @@
+from miniauth.auth import MiniAuth
+from miniauth.main import (main, save_user, remove_user, disable_user,
+                           enable_user, verify_user, verify_user_from_opts,
+                           EX_ALREADY_EXISTS, EX_OK, EX_NOUSER, EX_SOFTWARE,
+                           EX_VERIFYFAILD)
+from mock import Mock
+from tests.helpers import BaseTestCase
+
+
+class TestSaveUser(BaseTestCase):
+    def setUp(self):
+        self.mock_logger = self.patch('miniauth.main.logger')
+        self.mock_auth = Mock()
+        self.mock_auth.user_exists.return_value = False
+
+    def test_save_user_checks_user_exists_then_creates_user_and_returns_ok(self):
+        self.assertEqual(
+            save_user(self.mock_auth, 'testuser', 'testpassword', 'sha512'),
+            EX_OK
+        )
+        self.mock_auth.user_exists.assert_called_once_with('testuser')
+        self.mock_auth.create_user.assert_called_once_with(
+            'testuser',
+            'testpassword',
+            hash_func='sha512'
+        )
+
+    def test_save_user_returns_already_exists_code_by_default_when_user_exists(self):
+        self.mock_auth.user_exists.return_value = True
+        self.assertEqual(
+            save_user(self.mock_auth, 'test', 'test', 'sha512'),
+            EX_ALREADY_EXISTS
+        )
+        self.assertFalse(self.mock_auth.create_user.called)
+
+    def test_save_user_creates_user_and_returns_ok_when_user_exists_by_force_set(self):
+        self.mock_auth.user_exists.return_value = True
+        self.assertEqual(
+            save_user(self.mock_auth, 'testuser', 'testpassword', 'sha512', force=True),
+            EX_OK
+        )
+        self.mock_auth.create_user.assert_called_once_with(
+            'testuser',
+            'testpassword',
+            hash_func='sha512'
+        )
+
+
+class TestRemoveUser(BaseTestCase):
+    def setUp(self):
+        self.mock_logger = self.patch('miniauth.main.logger')
+        self.mock_auth = Mock()
+        self.mock_auth.delete_user.return_value = False
+
+    def test_remove_user_deletes_user_and_returns_ok_if_existed(self):
+        self.mock_auth.delete_user.return_value = True
+        self.assertEqual(
+            remove_user(self.mock_auth, 'testuser'),
+            EX_OK
+        )
+        self.mock_auth.delete_user.assert_called_once_with('testuser')
+
+    def test_remove_user_returns_ex_nouser_if_user_didnt_exist(self):
+        self.assertEqual(
+            remove_user(self.mock_auth, 'testuser'),
+            EX_NOUSER
+        )
+
+    def test_remove_user_returns_ex_ok_if_user_didnt_exist_but_ignore_missing_set(self):
+        self.assertEqual(
+            remove_user(self.mock_auth, 'testuser', True),
+            EX_OK
+        )
+        self.mock_auth.delete_user.assert_called_once_with('testuser')
+
+
+class TestDisableUser(BaseTestCase):
+    def setUp(self):
+        self.mock_logger = self.patch('miniauth.main.logger')
+        self.mock_auth = Mock()
+        self.mock_auth.user_exists.return_value = True
+        self.mock_auth.disable_user.return_value = True
+
+    def test_disable_user_checks_user_exists_disables_if_not_and_return_ok(self):
+        self.assertEqual(
+            disable_user(self.mock_auth, 'testuser'),
+            EX_OK
+        )
+        self.mock_auth.user_exists.assert_called_once_with('testuser')
+        self.mock_auth.disable_user.assert_called_once_with('testuser')
+
+    def test_disable_user_wont_call_disable_but_returns_no_user_when_user_doesnt_exist(self):
+        self.mock_auth.user_exists.return_value = False
+        self.assertEqual(
+            disable_user(self.mock_auth, 'testuser'),
+            EX_NOUSER
+        )
+        self.mock_auth.user_exists.assert_called_once_with('testuser')
+        self.assertFalse(self.mock_auth.disable_user.called)
+
+    def test_disable_user_wont_disable_returns_ok_when_user_doesnt_exist_and_ignore_missing_set(self):
+        self.mock_auth.user_exists.return_value = False
+        self.assertEqual(
+            disable_user(self.mock_auth, 'testuser', True),
+            EX_OK
+        )
+        self.mock_auth.user_exists.assert_called_once_with('testuser')
+        self.assertFalse(self.mock_auth.disable_user.called)
+
+    def test_disable_user_returns_ex_software_if_failed_to_disable(self):
+        self.mock_auth.disable_user.return_value = False
+        self.assertEqual(
+            disable_user(self.mock_auth, 'testuser', True),
+            EX_SOFTWARE
+        )
+
+
+class TestEnableUser(BaseTestCase):
+    def setUp(self):
+        self.mock_logger = self.patch('miniauth.main.logger')
+        self.mock_auth = Mock()
+        self.mock_auth.user_exists.return_value = True
+        self.mock_auth.enable_user.return_value = True
+
+    def test_enable_user_checks_user_exists_enables_if_not_and_return_ok(self):
+        self.assertEqual(
+            enable_user(self.mock_auth, 'testuser'),
+            EX_OK
+        )
+        self.mock_auth.user_exists.assert_called_once_with('testuser')
+        self.mock_auth.enable_user.assert_called_once_with('testuser')
+
+    def test_enable_user_wont_call_enable_but_returns_no_user_when_user_doesnt_exist(self):
+        self.mock_auth.user_exists.return_value = False
+        self.assertEqual(
+            enable_user(self.mock_auth, 'testuser'),
+            EX_NOUSER
+        )
+        self.mock_auth.user_exists.assert_called_once_with('testuser')
+        self.assertFalse(self.mock_auth.enable_user.called)
+
+    def test_enable_user_wont_enable_returns_ok_when_user_doesnt_exist_and_ignore_missing_set(self):
+        self.mock_auth.user_exists.return_value = False
+        self.assertEqual(
+            enable_user(self.mock_auth, 'testuser', True),
+            EX_OK
+        )
+        self.mock_auth.user_exists.assert_called_once_with('testuser')
+        self.assertFalse(self.mock_auth.enable_user.called)
+
+    def test_enable_user_returns_ex_software_if_failed_to_enable(self):
+        self.mock_auth.enable_user.return_value = False
+        self.assertEqual(
+            enable_user(self.mock_auth, 'testuser', True),
+            EX_SOFTWARE
+        )
+
+
+class TestVerifyUser(BaseTestCase):
+    def setUp(self):
+        self.mock_logger = self.patch('miniauth.main.logger')
+        self.mock_auth = Mock()
+        self.mock_auth.verify_user.return_value = True
+
+    def test_verify_user_calls_auth_verify_returns_ok_when_verified(self):
+        self.assertEqual(
+            verify_user(self.mock_auth, 'testuser', 'testpassword'),
+            EX_OK
+        )
+        self.mock_auth.verify_user.assert_called_once_with('testuser', 'testpassword')
+
+    def test_verify_returns_verifyfailed_when_not_verified(self):
+        self.mock_auth.verify_user.return_value = False
+        self.assertEqual(
+            verify_user(self.mock_auth, 'testuser', 'testpassword'),
+            EX_VERIFYFAILD
+        )
+
+
+class TestVerifyUserFromOpts(BaseTestCase):
+    def setUp(self):
+        self.mock_auth = Mock()
+        self.mock_getpass = self.patch('miniauth.main.getpass')
+        self.mock_getpass.return_value = 'fromgetpass'
+        self.mock_prompt = self.patch('miniauth.main.prompt')
+        self.mock_prompt.return_value = 'fromprompt'
+        self.mock_read_lines = self.patch('miniauth.main.read_lines_from_file')
+        self.mock_verify = self.patch('miniauth.main.verify_user')
+        self.mock_verify.return_value = EX_OK
+        self.opts = Mock()
+        self.opts.user = 'testuser'
+        self.opts.password = 'testpassword'
+        self.opts.creds_file = ''
+        self.opts.password_file = ''
+
+    def test_verify_user_from_opts_gets_user_password_from_opts_calls_verify(self):
+        self.assertEqual(
+            verify_user_from_opts(self.mock_auth, self.opts),
+            EX_OK
+        )
+        self.mock_verify.assert_called_once_with(
+            self.mock_auth,
+            'testuser',
+            'testpassword'
+        )
+        self.assertFalse(self.mock_prompt.called)
+        self.assertFalse(self.mock_getpass.called)
+        self.assertFalse(self.mock_read_lines.called)
+
+    def test_verify_user_from_opts_prompts_user_password_if_empty(self):
+        self.opts.user = ''
+        self.opts.password = ''
+        verify_user_from_opts(self.mock_auth, self.opts)
+        self.assertTrue(self.mock_prompt.called)
+        self.assertTrue(self.mock_getpass.called)
+        self.mock_verify.assert_called_once_with(
+            self.mock_auth,
+            'fromprompt',
+            'fromgetpass'
+        )
+
+    def test_verify_user_from_opts_prompts_password_if_password_empty(self):
+        self.opts.password = ''
+        verify_user_from_opts(self.mock_auth, self.opts)
+        self.assertFalse(self.mock_prompt.called)
+        self.assertTrue(self.mock_getpass.called)
+        self.mock_verify.assert_called_once_with(
+            self.mock_auth,
+            'testuser',
+            'fromgetpass'
+        )
+
+    def test_verify_user_from_opts_reads_password_from_creds_file_if_password_empty(self):
+        self.opts.creds_file = '/tmp/creds_file'
+        self.opts.password = ''
+        self.mock_read_lines.return_value = ['userline', 'passline']
+
+        verify_user_from_opts(self.mock_auth, self.opts)
+
+        self.mock_read_lines.assert_called_once_with('/tmp/creds_file', 2)
+        self.assertFalse(self.mock_prompt.called)
+        self.assertFalse(self.mock_getpass.called)
+        self.mock_verify.assert_called_once_with(
+            self.mock_auth,
+            'testuser',
+            'passline'
+        )
+
+    def test_verify_user_from_opts_reads_user_password_from_creds_file_if_empty(self):
+        self.opts.creds_file = '/tmp/creds_file'
+        self.opts.user = ''
+        self.opts.password = ''
+        self.mock_read_lines.return_value = ['userline', 'passline']
+
+        verify_user_from_opts(self.mock_auth, self.opts)
+
+        self.mock_read_lines.assert_called_once_with('/tmp/creds_file', 2)
+        self.assertFalse(self.mock_prompt.called)
+        self.assertFalse(self.mock_getpass.called)
+        self.mock_verify.assert_called_once_with(
+            self.mock_auth,
+            'userline',
+            'passline'
+        )
+
+    def test_verify_user_from_opts_raises_valerr_when_user_is_empty_in_opts_and_creds_file(self):
+        self.opts.creds_file = '/tmp/creds_file'
+        self.opts.user = ''
+        self.mock_read_lines.return_value = ['', 'passline']
+
+        with self.assertRaises(ValueError):
+            verify_user_from_opts(self.mock_auth, self.opts)
+
+    def test_verify_user_from_opts_raises_valerr_when_passowrd_is_empty_in_opts_and_creds_file(self):
+        self.opts.creds_file = '/tmp/creds_file'
+        self.opts.password = ''
+        self.mock_read_lines.return_value = ['userline', '']
+
+        with self.assertRaises(ValueError):
+            verify_user_from_opts(self.mock_auth, self.opts)
+
+    def test_verify_user_from_opts_reads_password_from_password_file_if_password_empty(self):
+        self.opts.password_file = '/tmp/password_file'
+        self.opts.password = ''
+        self.mock_read_lines.return_value = ['passline']
+
+        verify_user_from_opts(self.mock_auth, self.opts)
+
+        self.mock_read_lines.assert_called_once_with('/tmp/password_file', 1)
+        self.assertFalse(self.mock_prompt.called)
+        self.assertFalse(self.mock_getpass.called)
+        self.mock_verify.assert_called_once_with(
+            self.mock_auth,
+            'testuser',
+            'passline'
+        )
+
+    def test_verify_user_from_opts_raises_valerr_when_passowrd_is_empty_in_opts_and_passfile(self):
+        self.opts.password_file = '/tmp/password_file'
+        self.opts.password = ''
+        self.mock_read_lines.return_value = ['']
+
+        with self.assertRaises(ValueError):
+            verify_user_from_opts(self.mock_auth, self.opts)
+
+
+class TestMain(BaseTestCase):
+    def setUp(self):
+        self.mock_logger = self.patch('miniauth.main.logger')
+        self.mock_getpass = self.patch('miniauth.main.getpass')
+        self.mock_getpass.return_value = 'fromgetpass'
+        self.mock_verify = self.patch('miniauth.main.verify_user_from_opts')
+        self.mock_verify.return_value = EX_VERIFYFAILD
+        self.mock_save = self.patch('miniauth.main.save_user')
+        self.mock_save.return_value = EX_OK
+        self.mock_remove = self.patch('miniauth.main.remove_user')
+        self.mock_remove.return_value = EX_NOUSER
+        self.mock_disable = self.patch('miniauth.main.disable_user')
+        self.mock_disable.return_value = EX_SOFTWARE
+        self.mock_enable = self.patch('miniauth.main.enable_user')
+        self.mock_enable.return_value = EX_OK
+
+    def test_main_calls_verify_on_verify_action_returns_the_result(self):
+        self.assertEqual(
+            main(['verify', 'testuser', 'testpassword']),
+            EX_VERIFYFAILD
+        )
+        self.assertTrue(self.mock_verify.called)
+        auth, opts = self.mock_verify.call_args[0]
+        self.assertEqual(opts.user, 'testuser')
+        self.assertEqual(opts.password, 'testpassword')
+        self.assertIsInstance(auth, MiniAuth)
+
+    def test_main_calls_save_user_on_save_action_returns_the_result(self):
+        self.assertEqual(
+            main(['save', '-p', 'testpassword', '--force', '--hash', 'sha256', 'testuser']),
+            EX_OK
+        )
+        self.assertTrue(self.mock_save.called)
+        auth, user, password, hash_, force = self.mock_save.call_args[0]
+        self.assertEqual(user, 'testuser')
+        self.assertEqual(password, 'testpassword')
+        self.assertTrue(force)
+        self.assertEqual(hash_, 'sha256')
+        self.assertIsInstance(auth, MiniAuth)
+
+    def test_main_prompts_password_if_password_is_not_set(self):
+        self.assertEqual(
+            main(['save', 'testuser']),
+            EX_OK
+        )
+        self.assertTrue(self.mock_getpass.called)
+        self.assertTrue(self.mock_save.called)
+        auth, user, password, hash_, force = self.mock_save.call_args[0]
+        self.assertEqual(user, 'testuser')
+        self.assertEqual(password, 'fromgetpass')
+        self.assertFalse(force)
+        self.assertEqual(hash_, 'sha512')
+        self.assertIsInstance(auth, MiniAuth)
+
+    def test_main_calls_remove_user_on_remove_action_returns_the_result(self):
+        self.assertEqual(
+            main(['remove', '--ignore-missing', 'testuser']),
+            EX_NOUSER
+        )
+        self.assertTrue(self.mock_remove.called)
+        auth, user, ignore_missing = self.mock_remove.call_args[0]
+        self.assertEqual(user, 'testuser')
+        self.assertTrue(ignore_missing)
+        self.assertIsInstance(auth, MiniAuth)
+
+    def test_main_calls_disable_user_on_disable_action_returns_the_result(self):
+        self.assertEqual(
+            main(['disable', '--ignore-missing', 'testuser']),
+            EX_SOFTWARE
+        )
+        self.assertTrue(self.mock_disable.called)
+        auth, user, ignore_missing = self.mock_disable.call_args[0]
+        self.assertEqual(user, 'testuser')
+        self.assertTrue(ignore_missing)
+        self.assertIsInstance(auth, MiniAuth)
+
+    def test_main_calls_enable_user_on_enable_action_returns_the_result(self):
+        self.assertEqual(
+            main(['enable', '--ignore-missing', 'testuser']),
+            EX_OK
+        )
+        self.assertTrue(self.mock_enable.called)
+        auth, user, ignore_missing = self.mock_enable.call_args[0]
+        self.assertEqual(user, 'testuser')
+        self.assertTrue(ignore_missing)
+        self.assertIsInstance(auth, MiniAuth)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,93 @@
+from miniauth.utils import (MemTextIO, prompt,
+                            read_lines_from_stream,
+                            read_lines_from_file)
+from tests.helpers import BaseTestCase, HasTempfileTestCase
+
+
+class TestPrompt(BaseTestCase):
+    def setUp(self):
+        self.mock_input = self.patch('miniauth.utils._raw_input')
+        self.mock_input.return_value = 'test\n'
+
+    def test_prompt_passes_message_to_raw_input(self):
+        prompt('context?')
+        self.mock_input.assert_called_once_with('context?')
+
+    def test_prompt_returns_stripped_raw_input_results(self):
+        self.assertEqual(prompt(), 'test')
+
+
+class TestReadLinesFromStream(BaseTestCase):
+    def setUp(self):
+        self.stream = MemTextIO()
+        self.stream.write("\n".join([str(v) for v in range(3)]))
+        self.stream.seek(0)
+
+    def test_read_lines_from_stream_reads_all_lines_when_no_count(self):
+        self.assertEqual(
+            read_lines_from_stream(self.stream),
+            ['0', '1', '2']
+        )
+
+    def test_read_lines_from_stream_reads_specified_lines_count_only(self):
+        self.assertEqual(
+            read_lines_from_stream(self.stream, 1),
+            ['0']
+        )
+
+    def test_read_lines_from_stream_returns_none_for_missing_lines(self):
+        self.assertEqual(
+            read_lines_from_stream(self.stream, 5),
+            ['0', '1', '2', None, None]
+        )
+
+    def test_read_lines_from_stream_returns_lines_stripping_new_lines_only(self):
+        self.stream.write(" left space\n")
+        self.stream.write("right space \n")
+        self.stream.write("\n")
+        self.stream.write(" both space \n")
+        self.stream.seek(0)
+        self.assertEqual(
+            read_lines_from_stream(self.stream),
+            [' left space', 'right space ', '', ' both space ']
+        )
+
+
+class TestReadLinesFromFrop(HasTempfileTestCase):
+    _temp_file_mode = 'w+t'
+
+    def setUp(self):
+        HasTempfileTestCase.setUp(self)
+        self._tempfile.write("\n".join([str(v) for v in range(3)]))
+        self._tempfile.flush()
+        self._tempfile.seek(0)
+
+    def test_read_lines_from_file_reads_all_lines_when_no_count(self):
+        self.assertEqual(
+            read_lines_from_file(self._tempfile_name),
+            ['0', '1', '2']
+        )
+
+    def test_read_lines_from_file_reads_specified_lines_count_only(self):
+        self.assertEqual(
+            read_lines_from_file(self._tempfile_name, 1),
+            ['0']
+        )
+
+    def test_read_lines_from_line_returns_none_for_missing_lines(self):
+        self.assertEqual(
+            read_lines_from_file(self._tempfile_name, 5),
+            ['0', '1', '2', None, None]
+        )
+
+    def test_read_lines_from_line_returns_lines_stripping_new_lines_only(self):
+        self._tempfile.write(" left space\n")
+        self._tempfile.write("right space \n")
+        self._tempfile.write("\n")
+        self._tempfile.write(" both space \n")
+        self._tempfile.flush()
+        self._tempfile.seek(0)
+        self.assertEqual(
+            read_lines_from_file(self._tempfile_name),
+            [' left space', 'right space ', '', ' both space ']
+        )


### PR DESCRIPTION
Implement `main` module, a CLI app using `MiniAuth` to manage a local user DB using SQlite storage.
Supports different actions

- `save`: new records or update existing ones
- `verify`: verify credentials against the saved DB, supports reading user/password from CLI args, prompting user if not specified, or reading the password from a password file or both user/password from a credential file
- `disable`: mark users disabled
- `enable`: mark user enabled
` `remove`: remove exiting users from DB

```
farzad ~/p/miniauth (implement-main)> python miniauth/main.py --help
usage: miniauth [-h] [-s STORAGE] [-q] [-v] [--version]
                {save,remove,disable,enable,verify} ...

manage a database of users

positional arguments:
  {save,remove,disable,enable,verify}
                        available actions
    save                create or update a user
    remove              remove a user
    disable             disable an existing user
    enable              enable an existing user
    verify              verify user credentials

optional arguments:
  -h, --help            show this help message and exit
  -s STORAGE, --storage STORAGE
                        the auth storage. default is miniauth.db
  -q, --quiet           run in quiet mode (overwrites verbose)
  -v, --verbose         run in verbose mode
  --version             show program's version number and exit
```

Exit codes are used to report the results.