### PR TITLE
Cli entrypoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ after_success:
   - "pip install dist/*.whl"
   - "python -c 'import miniauth'"
   - "python -c 'import miniauth.main'"
+  - "miniauth --version"
 
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -21,14 +21,42 @@ has no dependencies other than Python standard library.
    False
 
 
-A CLI tool helps to use a local database of users.
+When the package is installed, a CLI tool is provided to manage and use a local database of users,
+using a SQLite backend.
 
 .. code-block::
 
    $ miniauth save testuser
    Password:
+   # miniauth.db is a SQLite DB created in pwd
+
    $ miniauth verify testuser
    Password:
+   # exit codes report the result of verification
+
+   $ miniauth --help
+   usage: miniauth [-h] [-s STORAGE] [-q] [-v] [--version]
+                   {save,remove,disable,enable,verify} ...
+
+   manage a database of users
+
+   positional arguments:
+     {save,remove,disable,enable,verify}
+                           available actions
+       save                create or update a user
+       remove              remove a user
+       disable             disable an existing user
+       enable              enable an existing user
+       verify              verify user credentials
+
+   optional arguments:
+     -h, --help            show this help message and exit
+     -s STORAGE, --storage STORAGE
+                           the auth storage. default is miniauth.db
+     -q, --quiet           run in quiet mode (overwrites verbose)
+     -v, --verbose         run in verbose mode
+     --version             show program's version number and exit
+
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,15 @@ has no dependencies other than Python standard library.
    False
 
 
+A CLI tool helps to use a local database of users.
+
+.. code-block::
+
+   $ miniauth save testuser
+   Password:
+   $ miniauth verify testuser
+   Password:
+
 
 Installation
 ============

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,10 @@ setup_params = dict(
     classifiers=classifiers,
     keywords='auth userdb',
     test_suite='tests',
-    zip_safe=True
+    zip_safe=True,
+    entry_points=dict(
+        console_scripts=['miniauth=miniauth.main:main']
+    ),
 )
 
 setup_params["extras_require"] = {"dev": ["pytest", "mock", "typing", "pycodestyle"]}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py3,py27
 [testenv]
 deps = -rrequirements/dev.txt
 commands = pytest {posargs:tests}
+           miniauth --version
 setenv =
     PYTHONPATH = {toxinidir}
 
@@ -13,3 +14,4 @@ deps = -rrequirements/dev.txt
 commands = mypy --config-file={toxinidir}/mypy.ini miniauth tests
            pytest {posargs:tests}
            pycodestyle --config pycodestyle.ini miniauth tests setup.py
+           miniauth --version


### PR DESCRIPTION
Add a CLI entrypoint to the package:

```
miniauth --help
usage: miniauth [-h] [-s STORAGE] [-q] [-v] [--version]
                {save,remove,disable,enable,verify} ...

manage a database of users

positional arguments:
  {save,remove,disable,enable,verify}
                        available actions
    save                create or update a user
    remove              remove a user
    disable             disable an existing user
    enable              enable an existing user
    verify              verify user credentials

optional arguments:
  -h, --help            show this help message and exit
  -s STORAGE, --storage STORAGE
                        the auth storage. default is miniauth.db
  -q, --quiet           run in quiet mode (overwrites verbose)
  -v, --verbose         run in verbose mode
  --version             show program's version number and exit
```