### PR TITLE
Log to file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,11 +3,58 @@ MiniAuth
 ********
 
 MiniAuth is a small program (and a Python library) for user authentication,
-providing an interface easy to integrate with other programs.
+with handy features, making it easy to use in different contexts and integrate with other programs.
 
-It's designed to be simple and portable.
-MiniAuth is written in Python, supports Python versions 2.7 and Python 3.4+,
+MiniAuth is simple and portable, runs on Python versions 2.7 and Python 3.4+ and
 has no dependencies other than Python standard library.
+
+When the Python package is installed, the `miniauth` CLI entrypoint is provided to manage and use a local database of users,
+using a SQLite backend.
+
+Here is how to create a user and password, then verifying the credentials:
+
+.. code-block::
+
+   $ miniauth save testuser
+   Password:
+
+   $ miniauth verify testuser
+   Password:
+   # exit codes report the result of verification
+
+
+By default a SQLite DB file is created in current working directory named `miniauth.db`.
+The path to this file can be configured with the `--storage` option.
+
+When verifying the credentials, the password can be specified as an argument, or
+read from standard input or a file.
+
+.. code-block::
+
+   $ miniauth --storage=user.db --verbose save testuser --password testpassword
+   No DB detected on "user.db". Creating latest DB schema ...
+   DB schema updated to version user.db on "1"
+   created user testuser
+
+   # read password from arguments
+   $ miniauth --storage=user.db --verbose verify testuser testpassword
+   user testuser credentials are correct
+
+   # read password from a file
+   $ cat file_with_password
+   testpassword
+   $ miniauth --storage=user.db --verbose verify testuser --password-file file_with_password
+   user testuser credentials are correct
+
+   # read username and password from a file
+   $ cat file_with_creds
+   testuser
+   testpassword
+   $ miniauth --storage=user.db --verbose verify testuser --creds-file file_with_creds
+   user testuser credentials are correct
+
+
+Authenticating users can be done in other Python applications using miniauth as a library.
 
 .. code-block:: python
 
@@ -21,42 +68,16 @@ has no dependencies other than Python standard library.
    False
 
 
-When the package is installed, a CLI tool is provided to manage and use a local database of users,
-using a SQLite backend.
+MiniAuth can use storage backends other than the default SQLite based one.
+Storage classes should inherit `AbstractStorage` and implement the abstract methods.
 
-.. code-block::
+.. code-block:: python
 
-   $ miniauth save testuser
-   Password:
-   # miniauth.db is a SQLite DB created in pwd
-
-   $ miniauth verify testuser
-   Password:
-   # exit codes report the result of verification
-
-   $ miniauth --help
-   usage: miniauth [-h] [-s STORAGE] [-q] [-v] [--version]
-                   {save,remove,disable,enable,verify} ...
-
-   manage a database of users
-
-   positional arguments:
-     {save,remove,disable,enable,verify}
-                           available actions
-       save                create or update a user
-       remove              remove a user
-       disable             disable an existing user
-       enable              enable an existing user
-       verify              verify user credentials
-
-   optional arguments:
-     -h, --help            show this help message and exit
-     -s STORAGE, --storage STORAGE
-                           the auth storage. default is miniauth.db
-     -q, --quiet           run in quiet mode (overwrites verbose)
-     -v, --verbose         run in verbose mode
-     --version             show program's version number and exit
-
+   >>> from miniauth.storage import AbstractStorage
+   >>> class CustomStorage(AbstractStorage):
+   ...      # implement abstract methods
+   ...      pass
+   >>> auth = MiniAuth('', CustomStorage())
 
 
 Installation

--- a/miniauth/main.py
+++ b/miniauth/main.py
@@ -6,8 +6,8 @@ MiniAuth program interface.
 import sys
 from argparse import ArgumentParser
 from getpass import getpass
-from logging import (getLogger, INFO, DEBUG, Logger,
-                     StreamHandler, NullHandler)
+from logging import (getLogger, INFO, DEBUG, Logger, Formatter,
+                     StreamHandler, NullHandler, FileHandler)
 from miniauth import __version__
 from miniauth.auth import MiniAuth
 from miniauth.typing import Any, Text, Tuple
@@ -29,6 +29,7 @@ def parse_args(args=None):
     parser.add_argument('-s', '--storage', default='miniauth.db', help='the auth storage. default is miniauth.db')
     parser.add_argument('-q', '--quiet', action='store_true', help='run in quiet mode (overwrites verbose)')
     parser.add_argument('-v', '--verbose', action='store_true', help='run in verbose mode')
+    parser.add_argument('-l', '--log', help='file path to log to')
     parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
     subparsers = parser.add_subparsers(dest='action', help='available actions')
 
@@ -66,9 +67,15 @@ def parse_args(args=None):
     return parser.parse_args(args)
 
 
-def configure_logger(logger, quiet=False, debug=False):
-    # type: (Logger, bool, bool) -> None
+def configure_logger(logger, file_path=None, quiet=False, debug=False):
+    # type: (Logger, str, bool, bool) -> None
     logger.setLevel(DEBUG)
+    if file_path:
+        file_handler = FileHandler(file_path, mode='at', encoding='utf-8')
+        file_handler.setFormatter(Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        file_handler.setLevel(DEBUG)
+        logger.addHandler(file_handler)
+
     if quiet:
         logger.addHandler(NullHandler())
     else:
@@ -169,7 +176,7 @@ def verify_user_from_opts(mini_auth, opts):
 def main(args=None):
     try:
         opts = parse_args(args)
-        configure_logger(logger, quiet=opts.quiet, debug=opts.verbose)
+        configure_logger(logger, file_path=opts.log, quiet=opts.quiet, debug=opts.verbose)
 
         mini_auth = MiniAuth(db_path=opts.storage)
         if opts.action == 'verify':

--- a/miniauth/main.py
+++ b/miniauth/main.py
@@ -6,7 +6,8 @@ MiniAuth program interface.
 import sys
 from argparse import ArgumentParser
 from getpass import getpass
-from logging import getLogger, INFO, DEBUG, StreamHandler, Logger, NullHandler
+from logging import (getLogger, INFO, DEBUG, Logger,
+                     StreamHandler, NullHandler)
 from miniauth import __version__
 from miniauth.auth import MiniAuth
 from miniauth.typing import Any, Text, Tuple
@@ -168,7 +169,7 @@ def verify_user_from_opts(mini_auth, opts):
 def main(args=None):
     try:
         opts = parse_args(args)
-        configure_logger(logger, quiet=opts.quiet)
+        configure_logger(logger, quiet=opts.quiet, debug=opts.verbose)
 
         mini_auth = MiniAuth(db_path=opts.storage)
         if opts.action == 'verify':

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -412,3 +412,17 @@ class TestMain(BaseTestCase):
         self.assertEqual(self.mock_logger.addHandler.call_count, 1)
         handler = self.mock_logger.addHandler.call_args[0][0]
         self.assertIsInstance(handler, NullHandler)
+
+    def test_main_configures_logger_with_log_handler_debug_level_also_when_log_set(self):
+        mock_file_handler = Mock()
+        patched_file_handler = self.patch('miniauth.main.FileHandler')
+        patched_file_handler.return_value = mock_file_handler
+
+        main(['--log', '/tmp/testminiauthlog.txt', 'verify', 'testuser', 'testpassword']),
+
+        self.assertEqual(self.mock_logger.addHandler.call_count, 2)
+        self.assertEqual(self.mock_logger.addHandler.call_args_list[0][0][0], mock_file_handler)
+        mock_file_handler.setLevel.assert_called_once_with(DEBUG)
+        stream_handler = self.mock_logger.addHandler.call_args_list[1][0][0]
+        self.assertIsInstance(stream_handler, StreamHandler)
+        self.assertEqual(stream_handler.level, INFO)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,3 +1,5 @@
+import sys
+from logging import NullHandler, StreamHandler, INFO, DEBUG
 from miniauth.auth import MiniAuth
 from miniauth.main import (main, save_user, remove_user, disable_user,
                            enable_user, verify_user, verify_user_from_opts,
@@ -390,3 +392,23 @@ class TestMain(BaseTestCase):
         self.assertEqual(user, 'testuser')
         self.assertTrue(ignore_missing)
         self.assertIsInstance(auth, MiniAuth)
+
+    def test_main_configures_logger_with_stream_handler_by_default(self):
+        main(['verify', 'testuser', 'testpassword']),
+        self.assertEqual(self.mock_logger.addHandler.call_count, 1)
+        handler = self.mock_logger.addHandler.call_args[0][0]
+        self.assertIsInstance(handler, StreamHandler)
+        self.assertEqual(handler.level, INFO)
+
+    def test_main_configures_logger_with_stream_handler_debug_level_on_verbose(self):
+        main(['--verbose', 'verify', 'testuser', 'testpassword']),
+        self.assertEqual(self.mock_logger.addHandler.call_count, 1)
+        handler = self.mock_logger.addHandler.call_args[0][0]
+        self.assertIsInstance(handler, StreamHandler)
+        self.assertEqual(handler.level, DEBUG)
+
+    def test_main_configures_logger_with_null_handler_in_quiet_mode(self):
+        main(['--quiet', 'verify', 'testuser', 'testpassword']),
+        self.assertEqual(self.mock_logger.addHandler.call_count, 1)
+        handler = self.mock_logger.addHandler.call_args[0][0]
+        self.assertIsInstance(handler, NullHandler)


### PR DESCRIPTION
* Fix issue #6 by applying `--verbose` option
* Add feature to log to a file when `--log` is specified
* Improve README docs

```
$ miniauth --log miniauth.log save testuser --password testpassword
No DB detected on "miniauth.db". Creating latest DB schema ...
DB schema updated to version miniauth.db on "1"
$ cat miniauth.log 
2019-03-26 23:34:13,774 - miniauth.storage - INFO - No DB detected on "miniauth.db". Creating latest DB schema ...
2019-03-26 23:34:13,794 - miniauth.storage - INFO - DB schema updated to version miniauth.db on "1"
2019-03-26 23:34:13,800 - root - DEBUG - created user testuser

```