### PR TITLE
Disable user

### DIFF
--- a/miniauth/auth.py
+++ b/miniauth/auth.py
@@ -112,8 +112,10 @@ class MiniAuth(object):
         record = self._storage.get_record(username)
         return bool(record.get('disabled', False))
 
-    def verify_user(self, username, password):
-        # type: (Text, Text) -> bool
+    def verify_user(self, username, password, check_disabled=True):
+        # type: (Text, Text, bool) -> bool
         record = self._storage.get_record(username)
+        if check_disabled and record['disabled']:
+            return False
         password_hash = self.password_hash(password, record['hash_func'], record['salt'])
         return password_hash == record['password']

--- a/miniauth/main.py
+++ b/miniauth/main.py
@@ -131,6 +131,9 @@ def enable_user(mini_auth, user, ignore_missing=False):
 
 def verify_user(mini_auth, user, password):
     # type: (MiniAuth, Text, Text) -> int
+    if mini_auth.user_is_disabled(user):
+        logger.info("user {} is disabled".format(user))
+        return EX_VERIFYFAILD
     if mini_auth.verify_user(user, password):
         logger.debug("user {} credentials are correct".format(user))
         return EX_OK

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -29,7 +29,7 @@ class TestMiniAuth(BaseTestCase):
         self.mock_record = {
             'username': 'test',
             'password': self.password_hashed,
-            'disabled': True,
+            'disabled': False,
             'hash_func': 'sha256',
             'salt': '1111aaaa',
         }
@@ -172,10 +172,10 @@ class TestMiniAuth(BaseTestCase):
         self.assertTrue(ret)
         self.mock_storage.record_exists.assert_called_once_with('test')
 
-    def test_miniauth_user_is_disabled_return_disabled_field_of_record(self):
+    def test_miniauth_user_is_disabled_returns_disabled_field_of_record(self):
         self.mock_storage.get_record.return_value = self.mock_record
         ret = self.miniauth.user_is_disabled('test')
-        self.assertTrue(ret)
+        self.assertFalse(ret)
         self.mock_storage.get_record.assert_called_once_with('test')
 
     def test_miniauth_user_is_disabled_return_false_if_record_has_no_disabled(self):
@@ -191,7 +191,7 @@ class TestMiniAuth(BaseTestCase):
     def test_miniauth_verify_user_returns_true_if_password_hash_matches(self):
         self.assertTrue(self.miniauth.verify_user('test', 'abcd1234'))
 
-    def test_miniauth_verify_user_returns_false_if_password_hash_matches(self):
+    def test_miniauth_verify_user_returns_false_if_password_hash_doesnt_match(self):
         self.assertFalse(self.miniauth.verify_user('test', 'somethingelse'))
 
     def test_miniauth_verify_user_returns_false_if_password_is_empty(self):
@@ -210,3 +210,11 @@ class TestMiniAuth(BaseTestCase):
         self.mock_record['hash_func'] = ''
         self.mock_record['salt'] = ''
         self.assertFalse(self.miniauth.verify_user('test2', ''))
+
+    def test_miniauth_verify_user_returns_true_if_user_is_disabled_when_check_disabled_not_set(self):
+        self.mock_record['disabled'] = True
+        self.assertTrue(self.miniauth.verify_user('test', 'abcd1234', check_disabled=False))
+
+    def test_miniauth_verify_user_returns_false_if_user_is_disabled_when_check_disabled_set(self):
+        self.mock_record['disabled'] = True
+        self.assertFalse(self.miniauth.verify_user('test', 'abcd1234'))

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -163,6 +163,16 @@ class TestVerifyUser(BaseTestCase):
         self.mock_logger = self.patch('miniauth.main.logger')
         self.mock_auth = Mock()
         self.mock_auth.verify_user.return_value = True
+        self.mock_auth.user_is_disabled.return_value = False
+
+    def test_verify_user_checks_user_disabled_returns_verifyfailed_if_disabled(self):
+        self.mock_auth.user_is_disabled.return_value = True
+        self.assertEqual(
+            verify_user(self.mock_auth, 'testuser', 'testpassword'),
+            EX_VERIFYFAILD
+        )
+        self.mock_auth.user_is_disabled.assert_called_once_with('testuser')
+        self.assertFalse(self.mock_auth.verify_user.called)
 
     def test_verify_user_calls_auth_verify_returns_ok_when_verified(self):
         self.assertEqual(


### PR DESCRIPTION
* `MiniAuth.verify_user` checks if user is disabled or not. This check can be avoided if needed
* `main` checks if user is disabled and prints a related message to avoid confusion about incorrect credentials.

After this PR:
```
farzad@farzad-thinkpad miniauth 0$ miniauth save --force --password testpass testuser 
farzad@farzad-thinkpad miniauth 0$ miniauth disable testuser
farzad@farzad-thinkpad miniauth 0$ miniauth verify testuser testpass
user testuser is disabled
farzad@farzad-thinkpad miniauth 68$ echo $?
68
```  